### PR TITLE
Import Text component in SwipeableCardDeck

### DIFF
--- a/src/components/SwipeableCardDeck.tsx
+++ b/src/components/SwipeableCardDeck.tsx
@@ -3,6 +3,7 @@ import {
   View,
   StyleSheet,
   Alert,
+  Text,
 } from 'react-native';
 import CardStack, { Card } from 'react-native-deck-swiper';
 import { Take, TakeVote } from '../types';


### PR DESCRIPTION
## Summary
- import `Text` from `react-native` in `SwipeableCardDeck`

## Testing
- `npx tsc --noEmit` *(fails: type errors in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0a3be1ec8325a0cecca0ece03c3b