### PR TITLE
chore: remove api key debug logs

### DIFF
--- a/src/services/aiContentService.ts
+++ b/src/services/aiContentService.ts
@@ -182,14 +182,9 @@ const isContentUnique = async (newText: string, category: string): Promise<boole
 
 // Generate a single AI take for a specific category with uniqueness checking
 export const generateAITake = async (category?: string, maxRetries: number = 5): Promise<AIGeneratedTake> => {
-  // DEBUG: Check API key availability on device
-  const hasApiKey = !!OPENAI_API_KEY;
-  const keyLength = OPENAI_API_KEY?.length || 0;
-  console.log(`🔍 DEBUG - API Key available: ${hasApiKey}, length: ${keyLength}`);
-  
   if (!OPENAI_API_KEY) {
     const error = 'OpenAI API key not configured. Please set EXPO_PUBLIC_OPENAI_API_KEY in your environment.';
-    console.log(`❌ DEBUG - ${error}`);
+    console.error(error);
     throw new Error(error);
   }
 
@@ -287,7 +282,6 @@ Return ONLY the hot take text, nothing else.`;
       
       console.log(`⚡ OpenAI Request: temp=${requestPayload.temperature}, attempt=${attempt}`);
       console.log(`🔍 DEBUG - Making request to: ${OPENAI_API_URL}`);
-      console.log(`🔍 DEBUG - Using API key ending in: ...${OPENAI_API_KEY?.slice(-4)}`);
       
       const response = await fetch(OPENAI_API_URL, {
         method: 'POST',


### PR DESCRIPTION
## Summary
- remove OpenAI API key debug output from `aiContentService`

## Testing
- `npm run build` *(fails: Missing script "build")*
- `npx tsc --noEmit` *(fails: TypeScript errors in project but no API key output)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0a8101bc8325835202bc169d565c