### PR TITLE
Configure EAS update runtime

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,9 +15,11 @@
     <meta-data android:name="com.google.android.gms.ads.APPLICATION_ID" android:value="ca-app-pub-1745058833253836~8031915483" tools:replace="android:value"/>
     <meta-data android:name="com.google.android.gms.ads.flag.OPTIMIZE_AD_LOADING" android:value="true" tools:replace="android:value"/>
     <meta-data android:name="com.google.android.gms.ads.flag.OPTIMIZE_INITIALIZATION" android:value="true" tools:replace="android:value"/>
-    <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
+    <meta-data android:name="expo.modules.updates.ENABLED" android:value="true"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/7d390f1c-4d9b-4414-a359-2d8fd3f3ed43"/>
+    <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"/>
     <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
   <string name="app_name">Hot or Not Takes</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
+  <string name="expo_runtime_version">exposdk:53.0.0</string>
 </resources>

--- a/app.config.js
+++ b/app.config.js
@@ -50,7 +50,7 @@ export default () => ({
         projectId: "7d390f1c-4d9b-4414-a359-2d8fd3f3ed43"
       }
     },
-    runtimeVersion: { policy: "sdkVersion" },
+    runtimeVersion: "exposdk:53.0.0",
     updates: {
       enabled: true,
       url: "https://u.expo.dev/7d390f1c-4d9b-4414-a359-2d8fd3f3ed43"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "expo-dev-client": "~5.2.4",
         "expo-linear-gradient": "~14.1.5",
         "expo-status-bar": "~2.2.3",
+        "expo-updates": "~0.28.18",
         "firebase": "^12.0.0",
         "lodash": "^4.17.21",
         "react": "19.0.0",
@@ -5031,6 +5032,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.14.4.tgz",
+      "integrity": "sha512-TSL1BbBFIuXchJmPgbPnB7cGpOOuSGJcQ/L7gij/+zPjExwvKm5ckA5dlSulwoFhH8zQt4vb7bfISPSAWQVWBw==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "18.1.11",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz",
@@ -5135,6 +5142,40 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-structured-headers": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-4.1.0.tgz",
+      "integrity": "sha512-2X+aUNzC/qaw7/WyUhrVHNDB0uQ5rE12XA2H/rJXaAiYQSuOeU90ladaN0IJYV9I2XlhYrjXLktLXWbO7zgbag==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates": {
+      "version": "0.28.18",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.28.18.tgz",
+      "integrity": "sha512-qbxRF8w/xPNiEWmZHDxK4XJ0ns4A9VpQg66jNeAEc8mrX9f7TG3TyLyLtydAP0F4aTNrBcSxah8K5VA90vcPig==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/config": "~11.0.13",
+        "@expo/config-plugins": "~10.1.2",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "expo-eas-client": "~0.14.4",
+        "expo-manifests": "~0.16.6",
+        "expo-structured-headers": "~4.1.0",
+        "expo-updates-interface": "~1.1.0",
+        "glob": "^10.4.2",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-updates-interface": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.1.0.tgz",
@@ -5143,6 +5184,21 @@
       "peerDependencies": {
         "expo": "*"
       }
+    },
+    "node_modules/expo-updates/node_modules/@expo/code-signing-certificates": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.6.tgz",
+      "integrity": "sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==",
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "^1.3.3"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",
@@ -7108,9 +7164,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo-dev-client": "~5.2.4",
     "expo-linear-gradient": "~14.1.5",
     "expo-status-bar": "~2.2.3",
+    "expo-updates": "~0.28.18",
     "firebase": "^12.0.0",
     "lodash": "^4.17.21",
     "react": "19.0.0",


### PR DESCRIPTION
## Summary
- Install `expo-updates` after `eas update` prompted configuration for this bare app.
- Enable Android EAS Update metadata to match the existing EAS Updates project URL.
- Replace the unsupported runtime version policy with the existing native runtime value `exposdk:53.0.0`.

## Why
The Sprint 1 OTA publish failed because bare workflow projects cannot use runtime version policies. This persists the small release-infra fix before retrying the production update.

## Verification
- `npm run typecheck` passes.
- `git diff --check` passes.