### PR TITLE
[codex] Add server-side AI take generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,14 @@ User submissions are moderated by the `submitTake` Firebase HTTPS function befor
 - If OpenAI moderation fails, the function creates the take as `status: pending` / `isApproved: false`; pending takes are invisible to everyone except the submitter until manually reviewed in Firebase Console.
 - Firebase Cloud Functions secrets require the Firebase project to be on the Blaze plan.
 
-Legacy AI content generation is disabled in client builds. If generated content is needed again, build it as trusted server tooling rather than restoring a client API key.
+AI content generation is server-side only:
+
+- `useFirebaseTakes` asks the `generateTakes` HTTPS function for more content when the visible feed drops to 3 takes or fewer.
+- The client sends only the selected category and Firebase ID token; it never sends, stores, or derives an OpenAI key.
+- If the selected category is `all`, the function chooses the valid category with the fewest approved takes in Firestore so the library stays balanced over time.
+- Generated takes are moderated through the same local policy and OpenAI moderation path before they are written.
+- Approved generated takes are written with `status: approved`, `isApproved: true`, `isAIGenerated: true`, and `userId: ai-system`.
+- Generation failures are swallowed by the client; the user should never see an error or spinner because background generation failed.
 
 ## Build and Release Guardrails
 
@@ -91,7 +98,7 @@ Do not hide these warnings. Resolve dependency/tooling drift in a dedicated main
 
 ## Product Backlog
 
-Use `FUTURE_FEATURES.md` as the product idea backlog. Sprint 2 is currently focused on server-side submission moderation.
+Use `FUTURE_FEATURES.md` as the product idea backlog. Keep completed sprint notes here only when they change current operating behavior.
 
 ## Git Hygiene
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,10 +10,14 @@ initializeApp();
 const OPENAI_API_KEY = defineSecret('OPENAI_API_KEY');
 const OPENAI_MODERATION_URL = 'https://api.openai.com/v1/moderations';
 const OPENAI_MODERATION_MODEL = 'omni-moderation-latest';
+const OPENAI_CHAT_COMPLETIONS_URL = 'https://api.openai.com/v1/chat/completions';
+const OPENAI_GENERATION_MODEL = 'gpt-4o-mini';
+const AI_SYSTEM_USER_ID = 'ai-system';
 const MIN_TAKE_LENGTH = 10;
 const MAX_TAKE_LENGTH = 150;
+const GENERATED_TAKE_COUNT = 8;
 
-const VALID_CATEGORIES = new Set([
+const VALID_CATEGORY_LIST = [
   'food',
   'work',
   'pets',
@@ -27,13 +31,22 @@ const VALID_CATEGORIES = new Set([
   'sports',
   'travel',
   'relationships',
-]);
+] as const;
+
+type Category = (typeof VALID_CATEGORY_LIST)[number];
+
+const VALID_CATEGORIES = new Set<string>(VALID_CATEGORY_LIST);
 
 type TakeStatus = 'pending' | 'approved';
 
 interface SubmitTakeRequest {
   text?: unknown;
   category?: unknown;
+}
+
+interface GenerateTakesRequest {
+  category?: unknown;
+  requestingUserId?: unknown;
 }
 
 interface OpenAIModerationResult {
@@ -50,7 +63,57 @@ interface ModerationOutcome {
   reason?: string;
 }
 
+interface OpenAIChatCompletionResponse {
+  choices?: Array<{
+    message?: {
+      content?: string | null;
+    };
+  }>;
+}
+
+interface GeneratedTakeBatch {
+  takes?: unknown;
+}
+
 const db = getFirestore();
+
+const profanityWords = new Set([
+  'asshole',
+  'assholes',
+  'bitch',
+  'bitches',
+  'bullshit',
+  'cock',
+  'cum',
+  'cunt',
+  'dick',
+  'fuck',
+  'fucked',
+  'fucker',
+  'fuckers',
+  'fucking',
+  'piss',
+  'pissed',
+  'pussy',
+  'shit',
+  'shitty',
+]);
+
+const categoryGenerationGuidance: Record<Category, string> = {
+  food: 'Food, restaurants, cooking, dining habits, delivery, snacks, coffee, alcohol, and kitchen culture.',
+  work: 'Workplace norms, meetings, productivity, bosses, remote work, careers, ambition, and office culture.',
+  pets: 'Pet ownership, animal care, pet culture, training, expenses, and common pet-parent habits.',
+  technology: 'Consumer tech, social media, AI, phones, streaming, gadgets, privacy, and digital habits.',
+  life: 'Everyday routines, etiquette, growing up, friendship, money habits, time, chores, and personal choices.',
+  entertainment: 'Movies, TV, music, celebrities, books, fandoms, games, live events, and pop culture.',
+  environment: 'Climate, sustainability, recycling, transportation, energy use, conservation, and green habits.',
+  wellness: 'Fitness, sleep, mental health, nutrition, therapy, self-care, supplements, and health trends.',
+  society: 'Manners, culture, education, public spaces, family norms, generational debates, and social expectations.',
+  politics: 'Civic life, campaigns, institutions, policy tradeoffs, voting, public leadership, and political culture.',
+  sports: 'Teams, athletes, leagues, fans, rule changes, coaching, youth sports, and sports media.',
+  travel: 'Airports, hotels, tourism, road trips, packing, etiquette abroad, destinations, and vacation habits.',
+  relationships: 'Dating, marriage, friendship, boundaries, communication, breakups, commitment, and modern romance.',
+};
 
 const localRejectionRules: Array<{ pattern: RegExp; reason: string }> = [
   {
@@ -87,7 +150,7 @@ const sanitizeText = (value: unknown): string => {
   return text;
 };
 
-const sanitizeCategory = (value: unknown): string => {
+const sanitizeCategory = (value: unknown): Category => {
   if (typeof value !== 'string') {
     throw new HttpsError('invalid-argument', 'Category is required.');
   }
@@ -97,10 +160,45 @@ const sanitizeCategory = (value: unknown): string => {
     throw new HttpsError('invalid-argument', 'Please choose a valid category.');
   }
 
-  return category;
+  return category as Category;
+};
+
+const sanitizeGenerationCategory = (value: unknown): Category | 'all' => {
+  if (typeof value !== 'string') {
+    throw new HttpsError('invalid-argument', 'Category is required.');
+  }
+
+  const category = value.toLowerCase().trim();
+  if (category === 'all') {
+    return 'all';
+  }
+
+  if (!VALID_CATEGORIES.has(category)) {
+    throw new HttpsError('invalid-argument', 'Please choose a valid category.');
+  }
+
+  return category as Category;
 };
 
 const checkLocalPolicy = (text: string): ModerationOutcome => {
+  const words = text.toLowerCase().match(/[a-z']+/g) ?? [];
+  const profanityCount = words.filter((word) => profanityWords.has(word)).length;
+  const uniqueWords = new Set(words);
+
+  if (profanityCount >= 2 || (profanityCount > 0 && words.length <= 5)) {
+    return {
+      approved: false,
+      reason: 'Please turn the profanity into an actual take.',
+    };
+  }
+
+  if (words.length >= 4 && uniqueWords.size <= 2) {
+    return {
+      approved: false,
+      reason: 'Please submit a complete take, not repeated words.',
+    };
+  }
+
   for (const rule of localRejectionRules) {
     if (rule.pattern.test(text)) {
       return { approved: false, reason: rule.reason };
@@ -170,16 +268,176 @@ const moderateWithOpenAI = async (text: string): Promise<ModerationOutcome> => {
   return { approved: true };
 };
 
+const chooseLeastSuppliedCategory = async (): Promise<Category> => {
+  const counts = VALID_CATEGORY_LIST.reduce((acc, category) => {
+    acc[category] = 0;
+    return acc;
+  }, {} as Record<Category, number>);
+
+  const snapshot = await db
+    .collection('takes')
+    .where('isApproved', '==', true)
+    .select('category')
+    .get();
+
+  snapshot.forEach((doc) => {
+    const category = doc.get('category');
+    if (typeof category === 'string' && VALID_CATEGORIES.has(category)) {
+      counts[category as Category] += 1;
+    }
+  });
+
+  const selected = VALID_CATEGORY_LIST.reduce((best, category) => {
+    if (counts[category] < counts[best]) {
+      return category;
+    }
+    return best;
+  }, VALID_CATEGORY_LIST[0]);
+
+  logger.info('Selected least-supplied category for all-feed generation.', {
+    selected,
+    counts,
+  });
+
+  return selected;
+};
+
+const normalizeGeneratedTake = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const withoutPrefix = value
+    .replace(/\s+/g, ' ')
+    .replace(/^["']+|["']+$/g, '')
+    .replace(/^hot take:\s*/i, '')
+    .trim();
+
+  return withoutPrefix.length ? withoutPrefix : null;
+};
+
+const parseGeneratedTakes = (data: OpenAIChatCompletionResponse): string[] => {
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error('OpenAI generation returned no content.');
+  }
+
+  const parsed = JSON.parse(content) as GeneratedTakeBatch;
+  if (!Array.isArray(parsed.takes)) {
+    throw new Error('OpenAI generation returned an invalid take list.');
+  }
+
+  const seen = new Set<string>();
+  const takes: string[] = [];
+
+  for (const rawTake of parsed.takes) {
+    const normalized = normalizeGeneratedTake(rawTake);
+    if (!normalized) {
+      continue;
+    }
+
+    try {
+      const text = sanitizeText(normalized);
+      const duplicateKey = text.toLowerCase();
+      if (seen.has(duplicateKey)) {
+        continue;
+      }
+
+      seen.add(duplicateKey);
+      takes.push(text);
+    } catch {
+      // Skip malformed model output instead of failing the whole batch.
+    }
+  }
+
+  if (takes.length === 0) {
+    throw new Error('OpenAI generation returned no usable takes.');
+  }
+
+  return takes.slice(0, 10);
+};
+
+const generateTakeCandidates = async (category: Category): Promise<string[]> => {
+  const response = await fetch(OPENAI_CHAT_COMPLETIONS_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${OPENAI_API_KEY.value()}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: OPENAI_GENERATION_MODEL,
+      temperature: 0.95,
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You write short, human-sounding debate prompts for a swipe voting app. Return only JSON that matches the schema.',
+        },
+        {
+          role: 'user',
+          content:
+            `Generate ${GENERATED_TAKE_COUNT} fresh hot-or-not takes for the "${category}" category. ` +
+            `Category scope: ${categoryGenerationGuidance[category]} ` +
+            'Each take must be opinionated, specific, debatable, and feel like something a real person would post. ' +
+            'Use casual, direct phrasing with simple punctuation; avoid semicolons unless they are truly necessary. ' +
+            'Avoid generic filler, slurs, explicit sexual content, threats, medical advice, legal advice, hashtags, links, questions, and "hot take" prefixes. ' +
+            `Keep every take between ${MIN_TAKE_LENGTH} and ${MAX_TAKE_LENGTH} characters.`,
+        },
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'hot_take_batch',
+          strict: true,
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['takes'],
+            properties: {
+              takes: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => '');
+    throw new Error(`OpenAI generation failed with ${response.status}: ${errorBody.slice(0, 300)}`);
+  }
+
+  const data = (await response.json()) as OpenAIChatCompletionResponse;
+  return parseGeneratedTakes(data);
+};
+
+const takeTextExists = async (text: string): Promise<boolean> => {
+  const snapshot = await db
+    .collection('takes')
+    .where('text', '==', text)
+    .limit(1)
+    .get();
+
+  return !snapshot.empty;
+};
+
 const createTake = async ({
   text,
   category,
   userId,
   status,
+  isAIGenerated = false,
 }: {
   text: string;
-  category: string;
+  category: Category;
   userId: string;
   status: TakeStatus;
+  isAIGenerated?: boolean;
 }): Promise<string> => {
   const isApproved = status === 'approved';
   const takeData: FirebaseFirestore.DocumentData = {
@@ -194,7 +452,7 @@ const createTake = async ({
     isApproved,
     status,
     reportCount: 0,
-    isAIGenerated: false,
+    isAIGenerated,
   };
 
   if (isApproved) {
@@ -218,7 +476,7 @@ const httpStatusForError = (code: string): number => {
   }
 };
 
-const extractRequestData = (body: unknown): SubmitTakeRequest => {
+const extractRequestData = <T extends object>(body: unknown): T => {
   if (!body || typeof body !== 'object') {
     throw new HttpsError('invalid-argument', 'Request body is required.');
   }
@@ -229,23 +487,27 @@ const extractRequestData = (body: unknown): SubmitTakeRequest => {
     throw new HttpsError('invalid-argument', 'Submission data is required.');
   }
 
-  return data as SubmitTakeRequest;
+  return data as T;
 };
 
-const verifyFirebaseAuth = async (authHeader: string | undefined): Promise<string> => {
+const verifyFirebaseAuth = async (
+  authHeader: string | undefined,
+  action: string
+): Promise<string> => {
   const match = authHeader?.match(/^Bearer (.+)$/i);
   if (!match) {
-    throw new HttpsError('unauthenticated', 'You must be signed in to submit takes.');
+    throw new HttpsError('unauthenticated', `You must be signed in to ${action}.`);
   }
 
   try {
     const decodedToken = await getAuth().verifyIdToken(match[1]);
     return decodedToken.uid;
   } catch (error) {
-    logger.warn('Invalid Firebase auth token on submitTake request.', {
+    logger.warn('Invalid Firebase auth token on function request.', {
+      action,
       error: error instanceof Error ? error.message : String(error),
     });
-    throw new HttpsError('unauthenticated', 'You must be signed in to submit takes.');
+    throw new HttpsError('unauthenticated', `You must be signed in to ${action}.`);
   }
 };
 
@@ -271,8 +533,8 @@ export const submitTake = onRequest(
         throw new HttpsError('invalid-argument', 'submitTake accepts POST requests only.');
       }
 
-      const userId = await verifyFirebaseAuth(request.header('X-Firebase-Auth'));
-      const data = extractRequestData(request.body);
+      const userId = await verifyFirebaseAuth(request.header('X-Firebase-Auth'), 'submit takes');
+      const data = extractRequestData<SubmitTakeRequest>(request.body);
       const text = sanitizeText(data?.text);
       const category = sanitizeCategory(data?.category);
 
@@ -321,6 +583,131 @@ export const submitTake = onRequest(
         error instanceof Error && error.message
           ? error.message
           : 'Submission failed.';
+      response.status(httpStatusForError(code)).json({
+        error: {
+          status: code.toUpperCase().replace(/-/g, '_'),
+          message,
+        },
+      });
+    }
+  }
+);
+
+export const generateTakes = onRequest(
+  {
+    region: 'us-central1',
+    invoker: 'public',
+    secrets: [OPENAI_API_KEY],
+    timeoutSeconds: 60,
+  },
+  async (request, response) => {
+    response.set('Access-Control-Allow-Origin', '*');
+    response.set('Access-Control-Allow-Headers', 'Content-Type, X-Firebase-Auth');
+    response.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+
+    if (request.method === 'OPTIONS') {
+      response.status(204).send('');
+      return;
+    }
+
+    try {
+      if (request.method !== 'POST') {
+        throw new HttpsError('invalid-argument', 'generateTakes accepts POST requests only.');
+      }
+
+      const userId = await verifyFirebaseAuth(request.header('X-Firebase-Auth'), 'generate takes');
+      const data = extractRequestData<GenerateTakesRequest>(request.body);
+      const requestedCategory = sanitizeGenerationCategory(data?.category);
+      const category = requestedCategory === 'all' ? await chooseLeastSuppliedCategory() : requestedCategory;
+
+      if (typeof data.requestingUserId === 'string' && data.requestingUserId !== userId) {
+        logger.warn('generateTakes ignored mismatched requestingUserId.', {
+          authenticatedUserId: userId,
+          requestingUserId: data.requestingUserId,
+        });
+      }
+
+      const candidates = await generateTakeCandidates(category);
+      let addedCount = 0;
+      const skipped = {
+        duplicate: 0,
+        localPolicy: 0,
+        moderation: 0,
+      };
+      const takeIds: string[] = [];
+
+      for (const text of candidates) {
+        const isDuplicate = await takeTextExists(text);
+        if (isDuplicate) {
+          skipped.duplicate += 1;
+          continue;
+        }
+
+        const localPolicy = checkLocalPolicy(text);
+        if (!localPolicy.approved) {
+          skipped.localPolicy += 1;
+          continue;
+        }
+
+        try {
+          const moderation = await moderateWithOpenAI(text);
+          if (!moderation.approved) {
+            skipped.moderation += 1;
+            continue;
+          }
+        } catch (error) {
+          skipped.moderation += 1;
+          logger.error('OpenAI moderation failed for generated take; skipping candidate.', {
+            category,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          continue;
+        }
+
+        const takeId = await createTake({
+          text,
+          category,
+          userId: AI_SYSTEM_USER_ID,
+          status: 'approved',
+          isAIGenerated: true,
+        });
+        takeIds.push(takeId);
+        addedCount += 1;
+      }
+
+      logger.info('Generated takes request completed.', {
+        requestedBy: userId,
+        requestedCategory,
+        category,
+        generatedCount: candidates.length,
+        addedCount,
+        takeIds,
+        skipped,
+      });
+
+      response.status(200).json({
+        result: {
+          requestedCategory,
+          category,
+          generatedCount: candidates.length,
+          addedCount,
+          takeIds,
+          skipped,
+        },
+      });
+    } catch (error) {
+      const code = error instanceof HttpsError ? error.code : 'internal';
+      const message =
+        error instanceof HttpsError && error.message
+          ? error.message
+          : 'Failed to generate takes.';
+
+      if (!(error instanceof HttpsError)) {
+        logger.error('generateTakes failed.', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
       response.status(httpStatusForError(code)).json({
         error: {
           status: code.toUpperCase().replace(/-/g, '_'),

--- a/src/hooks/useFirebaseTakes.ts
+++ b/src/hooks/useFirebaseTakes.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { Take, TakeSubmission } from '../types/Take';
 import {
   submitTake,
+  requestGeneratedTakes,
   getUserVotedAndSkippedTakeIds,
   skipTake,
   fetchMoreTakesFilled,
@@ -26,7 +27,7 @@ interface UseFirebaseTakesResult {
   submitNewTake: (takeData: TakeSubmission) => Promise<void>;
   getUserVoteForTake: (takeId: string) => Promise<'hot' | 'not' | null>;
   refreshTakes: () => Promise<void>;
-  loadMore: (count?: number) => Promise<void>;
+  loadMore: (count?: number, force?: boolean, background?: boolean) => Promise<void>;
   hasMore: boolean;
   prependTake: (take: Take) => void;
 }
@@ -52,6 +53,8 @@ export const useFirebaseTakes = (options: UseFirebaseTakesOptions = {}): UseFire
 
   // Atomic guard against concurrent duplicate submits
   const inFlightVotesRef = useRef<Set<string>>(new Set());
+  const generationInFlightRef = useRef(false);
+  const generationTriggeredForRef = useRef<string | null>(null);
 
   // Stable category variety algorithm - freezes prefix to prevent reshuffling
   const ensureCategoryVariety = useCallback((takesArray: Take[], freezePrefixCount: number = 0): Take[] => {
@@ -186,11 +189,17 @@ export const useFirebaseTakes = (options: UseFirebaseTakesOptions = {}): UseFire
   }, [category, user, ensureCategoryVariety]);
 
   // Load more takes function
-  const loadMore = useCallback(async (count: number = 20) => {
-    if (!hasMore || loading) return;
+  const loadMore = useCallback(async (
+    count: number = 20,
+    force: boolean = false,
+    background: boolean = false
+  ) => {
+    if ((!force && !hasMore) || loading) return;
 
     try {
-      setLoading(true);
+      if (!background) {
+        setLoading(true);
+      }
       const interacted = new Set(interactedTakeIds);
       
       // Also exclude what's already in feed to avoid duplicates
@@ -223,15 +232,59 @@ export const useFirebaseTakes = (options: UseFirebaseTakesOptions = {}): UseFire
       setHasMore(gotAny && doubleFiltered.length > 0);
       console.log(`📝 Loaded ${doubleFiltered.length} more takes (filtered from ${items.length}), hasMore: ${gotAny}, total feed: ${feed.length + doubleFiltered.length}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load more takes');
+      if (!background) {
+        setError(err instanceof Error ? err.message : 'Failed to load more takes');
+      }
       console.error('Error in loadMore:', err);
     } finally {
-      setLoading(false);
+      if (!background) {
+        setLoading(false);
+      }
     }
   }, [category, feed, hasMore, loading, interactedTakeIds, ensureCategoryVariety]);
 
   // Return feed directly - variety is applied once during load, not on every render
   const takes = feed;
+
+  useEffect(() => {
+    if (!user || loading) {
+      return;
+    }
+
+    const generationKey = `${user.uid}:${category}`;
+    if (takes.length > 3) {
+      if (generationTriggeredForRef.current === generationKey) {
+        generationTriggeredForRef.current = null;
+      }
+      return;
+    }
+
+    if (
+      generationInFlightRef.current ||
+      generationTriggeredForRef.current === generationKey
+    ) {
+      return;
+    }
+
+    generationInFlightRef.current = true;
+    generationTriggeredForRef.current = generationKey;
+
+    requestGeneratedTakes(category)
+      .then((result) => {
+        if (result.addedCount > 0) {
+          resetFeedCursor(category);
+          loadMore(20, true, true).catch((err) => {
+            console.log('Background feed refill failed:', err);
+          });
+        }
+      })
+      .catch((err) => {
+        console.log('AI take generation skipped:', err instanceof Error ? err.message : err);
+      })
+      .finally(() => {
+        generationInFlightRef.current = false;
+      });
+  }, [category, loadMore, loading, takes.length, user]);
 
   // Submit a vote
   const handleSubmitVote = useCallback(async (

--- a/src/services/takeService.ts
+++ b/src/services/takeService.ts
@@ -20,11 +20,20 @@ import { Take, TakeSubmission, TakeStatus } from '../types/Take';
 // Collection references
 const TAKES_COLLECTION = 'takes';
 const SUBMIT_TAKE_URL = 'https://us-central1-hot-or-not-takes.cloudfunctions.net/submitTake';
+const GENERATE_TAKES_URL = 'https://us-central1-hot-or-not-takes.cloudfunctions.net/generateTakes';
 
 interface SubmitTakeResponse {
   takeId: string;
   status: TakeStatus;
   reason?: string;
+}
+
+interface GenerateTakesResponse {
+  requestedCategory: string;
+  category: string;
+  generatedCount: number;
+  addedCount: number;
+  takeIds?: string[];
 }
 
 const callSubmitTakeFunction = async (data: {
@@ -59,6 +68,37 @@ const callSubmitTakeFunction = async (data: {
   }
 
   return body.result as SubmitTakeResponse;
+};
+
+export const requestGeneratedTakes = async (category: string): Promise<GenerateTakesResponse> => {
+  const idToken = await auth.currentUser?.getIdToken();
+  if (!idToken) {
+    throw new Error('User must be signed in to generate takes');
+  }
+
+  const response = await fetch(GENERATE_TAKES_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Firebase-Auth': `Bearer ${idToken}`,
+    },
+    body: JSON.stringify({
+      data: {
+        category: category || 'all',
+      },
+    }),
+  });
+
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok || body.error) {
+    throw new Error(body.error?.message || 'Failed to generate takes');
+  }
+
+  if (typeof body.result?.addedCount !== 'number') {
+    throw new Error('Generation service returned an invalid response');
+  }
+
+  return body.result as GenerateTakesResponse;
 };
 
 // Convert Firestore timestamp to Date


### PR DESCRIPTION
## Summary
- Adds a `generateTakes` Firebase HTTPS function that generates a batch of AI takes with the OpenAI key kept in Firebase Secret Manager.
- Routes generated takes through local policy checks, OpenAI moderation, exact-text duplicate prevention, and Admin Firestore writes as approved AI content.
- Triggers background generation from `useFirebaseTakes` when the visible feed drops to 3 takes or fewer, with `all` resolved server-side to the least-supplied approved category.
- Updates `CLAUDE.md` with the current AI generation behavior and guardrails.

## Production deploy
- Deployed `submitTake` and `generateTakes` to Firebase project `hot-or-not-takes`.
- `generateTakes` is live at `https://us-central1-hot-or-not-takes.cloudfunctions.net/generateTakes`.
- Deploy still reports the known Node.js 20 runtime deprecation warning; this should be handled in a separate maintenance sprint.

## Validation
- `npm --prefix functions run typecheck`
- `npx tsc --noEmit`
- `npx expo-doctor` still reports the known SDK/tooling/native-folder maintenance warnings documented in `CLAUDE.md`.
- Smoke-tested `generateTakes` with an anonymous Firebase token against the app URL: `category: all` selected `relationships`, generated 8 candidates, added 8 approved AI takes, skipped 0.
- Smoke-tested `submitTake` regression: clean temporary take approved and then deleted; explicit phrase rejected with `Please keep submissions free of explicit sexual language.`